### PR TITLE
Use always last version of play services location

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
 
         <source-file src="src/android/RequestLocationAccuracy.java" target-dir="src/cordova/plugin" />
 
-        <framework src="com.google.android.gms:play-services-location:11.+" />
+        <framework src="com.google.android.gms:play-services-location:+" />
     </platform>
 
     <platform name="ios">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

Since the release of play-services 12.0 this plugin cause build issue with other plugin using a different library version
cordova-plugin-request-location-accuracy use google-play-services 11.+
cordova-plugin-firebase use google-play-services 12.0 

The solution is to use the last google-play-services library available 
com.google.android.gms:play-services-location:+
